### PR TITLE
Change in .spec file to reflect the config file rename

### DIFF
--- a/packaging/RPM/sendmailanalyzer.spec
+++ b/packaging/RPM/sendmailanalyzer.spec
@@ -162,7 +162,7 @@ fi
 %attr(0644,root,root) %{webdir}/lang/fr_FR
 %attr(0644,root,root) %{webdir}/lang/sp_SP
 %attr(0755,root,root) %{_sysconfdir}/rc.d/init.d/sendmailanalyzer
-%config(noreplace) %{_sysconfdir}/%{uname}.conf
+%config(noreplace) %{_sysconfdir}/%{uname}.conf.orig
 %config(noreplace) %{_sysconfdir}/cron.d/%{uname}
 %config(noreplace) %{_sysconfdir}/httpd/conf.d/%{uname}.conf
 %dir %{_localstatedir}/lib/%{uname}


### PR DESCRIPTION
Since the default config file got renamed from sendmailanalyzer.conf to sendmailanalyzer.conf.orig, the RPM will not build since it cannot find the sendmailanalyzer.conf file.

I've just appended the ".orig" suffix where it's needed, but I'm not sure if there is some more work to be done to bring the .spec up to date with the latest changes.
