### PR TITLE
Fix the .sample file install in doc folder when building an RPM

### DIFF
--- a/packaging/RPM/sendmailanalyzer.spec
+++ b/packaging/RPM/sendmailanalyzer.spec
@@ -150,7 +150,7 @@ fi
 
 %files
 %defattr(0644,root,root,0755)
-%doc Change* INSTALL README TODO README.RPM %{uname}.conf.sample
+%doc Change* INSTALL README TODO README.RPM
 %attr(0755,root,root) %{_bindir}/%{uname}
 %attr(0755,root,root) %{_bindir}/sa_cache
 %attr(0644,root,root) %{_mandir}/man3/%{uname}.3.gz


### PR DESCRIPTION
Currently, the RPM does not build. The issue is that it tries to copy the sendmailanalyzer.conf.sample file into /usr/share/doc/sendmailanalyzer-8.6/ folder, but that file does not exist and cannot be copied into the target folder.

This is expected, since the copying is done by install_all.sh script, so the file sendmailanalyzer.conf.sample is never actually created in the origin folder. Since unpackaged files won't terminate the RPM build, i simply let the install_all.sh handle the copying, and I can confirm that the sendmailanalyzer.conf.sample gets created just fine without getting specified in the %doc macro.
