### PR TITLE
Change all instances of 'coma' to 'comma'

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -152,12 +152,12 @@ SIZE_UNIT	MBytes
 # Max line to show in detail view. Default is 100
 MAX_LINE	100
 
-# List of admin users separated by coma
+# List of admin users separated by comma
 # They will have full access to all report
 #ADMIN   sa_admin
 
 #List of per user domain access control. The first field is the username and
-#the second field (separated by tabulation) is a coma separated list of domain
+#the second field (separated by tabulation) is a comma separated list of domain
 #name to be allowed to this user. You could add as many lines of DOMAIN_USER
 #as you want in the configuration file.
 #DOMAIN_USER	user1	domain1.com,domain3.com
@@ -177,7 +177,7 @@ AMAVIS_NAME	amavis
 # Default: lang/ERROR_CODE
 ERROR_CODE	lang/ERROR_CODE
 
-# Coma separated list of internal domain to be used when sendmailanalyzer is
+# Comma separated list of internal domain to be used when sendmailanalyzer is
 # running on a mail host which received message from any side. SA can't know
 # what message are internal or external in this case, so the only way to know
 # if a mail come from Internet or Lan/Wan is to check the domain part of the

--- a/README
+++ b/README
@@ -724,7 +724,7 @@ CONFIGURATION
         logged lines Can be overwritten with --spamd. Default is spamd.
 
     LOCAL_DOMAIN
-        Coma separated list of internal domain to be used when
+        Comma separated list of internal domain to be used when
         SendmailAnalyzer is running on a mail host which received message
         from any side. SA can't know what message are internal or external
         in this case, so the only way to know if a mail come from Internet
@@ -747,13 +747,13 @@ CONFIGURATION
                 LOCAL_HOST_DOMAIN   sysloghost2        domain3.com,domain4.com
 
     MAIL_HUB
-        FQDN coma separated list of internal mail hubs, aka: where email are
+        FQDN comma separated list of internal mail hubs, aka: where email are
         redirected if the host is a gateway. For example: mailhost.mydom.dom
         This directive is very important to help SendmailAnalyzer to find
         the direction of incoming and outgoing message.
 
     MAIL_GW
-        FQDN coma separated list of MTA gateways where external mail comes
+        FQDN comma separated list of MTA gateways where external mail comes
         from. This directive is very important to help SendmailAnalyzer to
         find the direction of incoming and outgoing message.
 
@@ -803,14 +803,14 @@ CONFIGURATION
         disable this feature.
 
     ADMIN
-        List of admins username separated by coma that must have full access
+        List of admins username separated by comma that must have full access
         to all report. The username is checked again the http REMOTE_USER
         environment variable. Default is every one can access, in this case
         you may want to add a .htaccess.
 
     DOMAIN_USER
         List of per user domain access control. The first field is the
-        username and the second field (separated by tabulation) is a coma
+        username and the second field (separated by tabulation) is a comma
         separated list of domain name to be allowed to this user. You could
         add as many lines of DOMAIN_USER as you want in the configuration
         file.

--- a/debian/sendmailanalyzer.conf
+++ b/debian/sendmailanalyzer.conf
@@ -105,12 +105,12 @@ SIZE_UNIT	MBytes
 # Max line to show in detail view. Default is 100
 MAX_LINE	100
 
-# List of admin users separated by coma
+# List of admin users separated by comma
 # They will have full access to all report
 #ADMIN   sa_admin
 
 #List of per user domain access control. The first field is the username and
-#the second field (separated by tabulation) is a coma separated list of domain
+#the second field (separated by tabulation) is a comma separated list of domain
 #name to be allowed to this user. You could add as many lines of DOMAIN_USER
 #as you want in the configuration file.
 #DOMAIN_USER	user1	domain1.com,domain3.com
@@ -130,7 +130,7 @@ AMAVIS_NAME	amavis
 # Default: lang/ERROR_CODE
 ERROR_CODE	lang/ERROR_CODE
 
-# Coma separated list of internal domain to be used when sendmailanalyzer is
+# Comma separated list of internal domain to be used when sendmailanalyzer is
 # running on a mail host which received message from any side. SA can't know
 # what message are internal or external in this case, so the only way to know
 # if a mail come from Internet or Lan/Wan is to check the domain part of the

--- a/doc/sendmailanalyzer.pod
+++ b/doc/sendmailanalyzer.pod
@@ -884,7 +884,7 @@ Can be overwritten with --spamd. Default is spamd.
 
 =item LOCAL_DOMAIN
 
-Coma separated list of internal domain to be used when SendmailAnalyzer
+Comma separated list of internal domain to be used when SendmailAnalyzer
 is running on a mail host which received message from any side. SA can't
 know what message are internal or external in this case, so the only way
 to know if a mail come from Internet or Lan/Wan is to check the domain
@@ -909,14 +909,14 @@ For example:
 
 =item MAIL_HUB
 
-FQDN coma separated list of internal mail hubs, aka: where email are
+FQDN comma separated list of internal mail hubs, aka: where email are
 redirected if the host is a gateway. For example: mailhost.mydom.dom
 This directive is very important to help SendmailAnalyzer to find the
 direction of incoming and outgoing message.
 
 =item MAIL_GW	
 
-FQDN coma separated list of MTA gateways where external mail comes from.
+FQDN comma separated list of MTA gateways where external mail comes from.
 This directive is very important to help SendmailAnalyzer to find the
 direction of incoming and outgoing message.
 
@@ -974,14 +974,14 @@ disable this feature.
 
 =item ADMIN
 
-List of admins username separated by coma that must have full access to all
+List of admins username separated by comma that must have full access to all
 report. The username is checked again the http REMOTE_USER environment variable.
 Default is every one can access, in this case you may want to add a .htaccess.
 
 =item DOMAIN_USER
 
 List of per user domain access control. The first field is the username and
-the second field (separated by tabulation) is a coma separated list of domain
+the second field (separated by tabulation) is a comma separated list of domain
 name to be allowed to this user. You could add as many lines of DOMAIN_USER
 as you want in the configuration file.
 


### PR DESCRIPTION
Minor documentation cleanup, change all instances of 'coma' to 'comma', since it refers to the punctuation mark
