### PR TITLE
Remove a rogue tab character from .spec, add pt_BR translation

### DIFF
--- a/packaging/RPM/sendmailanalyzer.spec
+++ b/packaging/RPM/sendmailanalyzer.spec
@@ -190,7 +190,7 @@ fi
 * Mon Dec 31 2012 Igor Vuk
 - Fix the .sample file install in doc folder.
 
-* Wed Dec 24 2012 Gilles Darold
+* Mon Dec 24 2012 Gilles Darold
 - Copy sendmailanalyzer.conf in _sysconfdir and sendmailanalyzer.conf.sample
   in _docdir
 


### PR DESCRIPTION
Replaced a tab character by four spaces, added '%attr(0644,root,root) %{webdir}/lang/pt_BR' for the pt_BR translation that was added after the last .spec file update, updated the changelog.
