### PR TITLE
Virtual doman support, wider regex for DNSBLs

### DIFF
--- a/cgi-bin/sa_report.cgi
+++ b/cgi-bin/sa_report.cgi
@@ -26,6 +26,7 @@ use MIME::QuotedPrint qw(decode_qp);
 use MIME::Base64 qw(decode_base64);
 use Time::Local 'timelocal_nocheck';
 use POSIX qw/ strftime /;
+use DBI;
 
 $| = 1;
 
@@ -245,6 +246,18 @@ if (-e $CONFIG{ERROR_CODE}) {
 # Print global header
 &sa_header($CGI) if (!$VIEW && !$DOWNLOAD);
 
+# Check if we have a SQL-host configured for virtual domains
+my $dbh;
+my $db_connected = 0;
+if( exists $CONFIG{VIRTUAL_DOMAIN_DB} ) {
+	$dbh = DBI->connect(
+			$CONFIG{VIRTUAL_DOMAIN_DB},
+			$CONFIG{VIRTUAL_DOMAIN_DB_USER},
+			$CONFIG{VIRTUAL_DOMAIN_DB_PASS},
+		) or die "Couldn't connect to database: " . DBI->errstr;
+	$db_connected = 1;
+}
+
 # Set default host report if there's only one host and no per domain report.
 my @syshost = get_list_host();
 if ( !$HOST && ($#syshost == 0) && ($#{$CONFIG{DOMAIN_REPORT}} == -1) && (scalar keys %{$CONFIG{DOMAIN_HOST_REPORT}} == 0) ) {
@@ -385,6 +398,11 @@ if (!$HOST) {
 &sa_footer($CGI) if (!$VIEW && !$DOWNLOAD);
 
 print $CGI->end_html() if (!$DOWNLOAD);
+
+#disconnect from database
+if( $db_connected ) {
+	$dbh->disconnect or warn "Disconnection error: $DBI::errstr\n";
+}
 
 exit 0;
 
@@ -1878,6 +1896,13 @@ sub set_direction
 		} elsif ($CONFIG{MAIL_GW} && $CONFIG{MAIL_HUB}) {
 			# If sender relay is the gateway, it comes from outside
 			$direction = 'Ext_' if (grep($STATS{$id}{sender_relay} =~ /$_/i, split(/[\s\t,;]/, $CONFIG{MAIL_GW})));
+		} elsif( exists $CONFIG{VIRTUAL_DOMAIN_DB} ) {
+				my $sth = $dbh->prepare( $CONFIG{VIRTUAL_DOMAIN_DB_QUERY} );
+				$sth->bind_param( 1, $STATS{$id}{sender_relay} );
+				$sth->execute;
+				if( $sth->rows == 0 ) {
+					$direction = 'Ext_';
+				}
 		}
 	} else {
 		$direction = 'Unk_';
@@ -1905,6 +1930,15 @@ sub set_direction
 				$direction .= 'Int';
 			} else {
 				$direction .= 'Ext';
+			}
+		} elsif( exists $CONFIG{VIRTUAL_DOMAIN_DB} ) {
+			my $sth = $dbh->prepare( $CONFIG{VIRTUAL_DOMAIN_DB_QUERY} );
+			$sth->bind_param( 1, $STATS{$id}{rcpt_relay}[$i] );
+			$sth->execute;
+			if( $sth->rows == 0 ) {
+				$direction .= 'Ext';
+			} else {
+				$direction .= 'Int';
 			}
 		# Finally his only way is to go outside
 		} else {

--- a/debian/sendmailanalyzer.conf
+++ b/debian/sendmailanalyzer.conf
@@ -148,6 +148,26 @@ ERROR_CODE	lang/ERROR_CODE
 # If you are running rsyslog with multiple host use LOCAL_HOST_DOMAIN instead.
 #LOCAL_DOMAIN   domain1.com domain2.com
 
+# If you're running a mailserver with virtual domains in a database this option
+# will allow sendmailanalyzer to perform domain-lookups in the database to 
+# determine whether this domain is external or internal (like the LOCAL_DOMAIN
+# option above. This will come with decent database load depending on how much
+# traffic your mailserver experiences as every domain will be matched against
+# your database.
+# Leave this unconfigured if you don't have virtual domains in a database set up
+# otherwise sendmailanalyzer will exit with an error.
+#VIRTUAL_DOMAIN_DB	DBI:mysql:database=mailserver:host=localhost
+
+# Username for the database connection
+#VIRTUAL_DOMAIN_DB_USER	mailserver
+
+# Password for the database connection
+#VIRTUAL_DOMAIN_DB_PASS	xyz
+
+# Query to select your domain from the database. Sendmailanalyzer will only count
+# the number of rows returned. If it's > 0 the domain is considered internal.
+#VIRTUAL_DOMAIN_DB_QUERY	SELECT `id` FROM `virtual_domains` WHERE `name`=?
+
 # Same as above but with host distinction for use with rsyslog.
 # You can have multiple LOCAL_HOST_DOMAIN lines, ie: one per host.
 #LOCAL_HOST_DOMAIN   sysloghost1	domain1.com domain2.com

--- a/sa_cache
+++ b/sa_cache
@@ -26,6 +26,7 @@ use Benchmark;
 use Getopt::Long;
 use POSIX qw / strftime :sys_wait_h /;
 use Time::Local 'timelocal_nocheck';
+use DBI;
 
 
 $VERSION     = '9.2';
@@ -102,6 +103,18 @@ if (!-d $CONFIG{OUT_DIR}) {
 
 my $cgi = new CGI;
 
+# Check if we have a SQL-host configured for virtual domains
+my $dbh;
+my $db_connected = 0;
+if( exists $CONFIG{VIRTUAL_DOMAIN_DB} ) {
+	$dbh = DBI->connect(
+			$CONFIG{VIRTUAL_DOMAIN_DB},
+			$CONFIG{VIRTUAL_DOMAIN_DB_USER},
+			$CONFIG{VIRTUAL_DOMAIN_DB_PASS},
+		) or die "Couldn't connect to database: " . DBI->errstr;
+	$db_connected = 1;
+}
+
 # Add global caching
 push(@{$CONFIG{DOMAIN_REPORT}}, '');
 
@@ -129,10 +142,10 @@ my @sysloghost = grep { !/^(data|lang|[\.]+)$/ && -d "$CONFIG{OUT_DIR}/$_" } rea
 closedir(DIR);
 
 foreach my $h (@sysloghost) {
-        next if ($HOST && ($h ne $HOST));
+	next if ($HOST && ($h ne $HOST));
 	$UNIQID = 0;
 	# Dump daily statistics
-	&cache_stat($cgi, $h);
+	&cache_stat($cgi, $h );
 }
 
 # Show total run time
@@ -141,6 +154,11 @@ my $td = timediff($t1, $t0);
 print "Cache generation took:",timestr($td),"\n";
 
 unlink("$CONFIG{PID_DIR}/$PID_FILE");
+
+#disconnect from database
+if( $db_connected ) {
+	$dbh->disconnect or warn "Disconnection error: $DBI::errstr\n";
+}
 
 exit 0;
 
@@ -187,8 +205,8 @@ sub read_config
 					} elsif ($var =~ /DOMAIN_HOST_REPORT/i) {
 						my ($hst, @doms) = split(/[\t,;\s]/, $val);
 						push(@{$CONFIG{DOMAIN_HOST_REPORT}{$hst}}, @doms);
-                                        } elsif ($var =~ /DOMAIN_REPORT/i) {
-                                                push(@{$CONFIG{DOMAIN_REPORT}}, split(/[\t,;\s]/, $val));
+					} elsif ($var =~ /DOMAIN_REPORT/i) {
+						push(@{$CONFIG{DOMAIN_REPORT}}, split(/[\t,;\s]/, $val));
 					} elsif ($var =~ /LOCAL_DOMAIN/i) {
 						push(@{$CONFIG{LOCAL_DOMAIN}}, split(/[\t,;\s]/, $val));
 					} elsif ($var =~ /LOCAL_HOST_DOMAIN/i) {
@@ -247,7 +265,7 @@ our %starttls = ();
 ####
 sub cache_stat
 {
-	my ($q, $hostname) = @_;
+	my ($q, $hostname ) = @_;
 
 	my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) = localtime(time);
 	$mon++;
@@ -4157,6 +4175,13 @@ sub set_direction
 				if (!grep($STATS->{$id}{sender_relay} =~ /\b$_$/i, @{$CONFIG{LOCAL_DOMAIN}})) {
 					$direction = 'Ext_';
 				}
+			} elsif( exists $CONFIG{VIRTUAL_DOMAIN_DB} ) {
+				my $sth = $dbh->prepare( $CONFIG{VIRTUAL_DOMAIN_DB_QUERY} );
+				$sth->bind_param( 1, $STATS->{$id}{sender_relay} );
+				$sth->execute;
+				if( $sth->rows == 0 ) {
+					$direction = 'Ext_';
+				}
 			} else {
 			# There's no local domain defined: impossible to know where message comes from
 			# Maybe you must review you configuration file or write som pieces of code here
@@ -4193,6 +4218,15 @@ sub set_direction
 			$direction .= 'Int';
 		} else {
 			$direction .= 'Ext';
+		}
+	} elsif( exists $CONFIG{VIRTUAL_DOMAIN_DB} ) {
+		my $sth = $dbh->prepare( $CONFIG{VIRTUAL_DOMAIN_DB_QUERY} );
+		$sth->bind_param( 1, $STATS->{$id}{rcpt_relay}[$i] );
+		$sth->execute;
+		if( $sth->rows == 0 ) {
+			$direction .= 'Ext';
+		} else {
+			$direction .= 'Int';
 		}
 	# Finally his only way is to go outside
 	} else {

--- a/sendmailanalyzer
+++ b/sendmailanalyzer
@@ -1344,8 +1344,8 @@ sub parse_sendmail
 		$reject =~ s/^\s+//;
 		$reject =~ s/[\s;]+$//;
 		# Test PostFix DNSBL spam scan
-		if ($reject =~ /client .* (blocked using .*)/i) {
-			my $spamdetail = $1;
+		if ($reject =~ /(client|helo) .* (blocked using .*)/i) {
+			my $spamdetail = $2;
 			$SPAM{$host}{$id}{relay} = $relay;
 			$SPAM{$host}{$id}{rule} = 'reject';
 			$SPAM{$host}{$id}{spam} = 'DNSBL Spam blocked';


### PR DESCRIPTION
Added support for virtual domains, so sendmailanalyzer can determine if a domain is internal or external. This extends the LOCAL_DOMAIN configuration option and is intended for mailserver which have a dynamic configuration from a SQL-like database. Uses DBI, so many different databases are supported.