### PR TITLE
fix parsing barracuda rbl

### DIFF
--- a/sendmailanalyzer
+++ b/sendmailanalyzer
@@ -1413,7 +1413,7 @@ sub parse_sendmail
 		$reject =~ s/^\s+//;
 		$reject =~ s/[\s;]+$//;
 		# Test PostFix DNSBL spam scan
-		if ($reject =~ /(?:client|helo) .* (blocked using .*)/i) {
+		if ($reject =~ /(?:client|helo) .* (blocked using .*;)/i) {
 			my $spamdetail = $1;
 			$SPAM{$host}{$id}{relay} = $relay;
 			$SPAM{$host}{$id}{rule} = 'reject';

--- a/sendmailanalyzer
+++ b/sendmailanalyzer
@@ -1413,7 +1413,7 @@ sub parse_sendmail
 		$reject =~ s/^\s+//;
 		$reject =~ s/[\s;]+$//;
 		# Test PostFix DNSBL spam scan
-		if ($reject =~ /(?:client|helo) .* (blocked using .*;)/i) {
+		if ($reject =~ /(?:client|helo) (?:.*?) (blocked using [^;]+)/i) {
 			my $spamdetail = $1;
 			$SPAM{$host}{$id}{relay} = $relay;
 			$SPAM{$host}{$id}{rule} = 'reject';


### PR DESCRIPTION
fix parsing:
Client host [1.1.1.1] blocked using b.barracudacentral.org; Client host blocked using Barracuda Reputation, see http://www.barracudanetworks.com/reputation/?r=1&ip=1.1.1.1